### PR TITLE
Don't allow hhvm to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,3 @@ after_success:
 
 addons:
   - code_climate
-
-matrix:
-  allow_failures:
-    - php: hhvm


### PR DESCRIPTION
Maybe we shouldn't allow hhvm to fail?
